### PR TITLE
feat: Add support to laravel 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /vendor
 composer.lock
 /phpunit.xml
-.phpunit.result.cache
+.phpunit.cache

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It's divided in two main elements:
 
 ## Requirements
 
-- PHP >= 7.4
-- Laravel >= 8.0
+- PHP >= 8.1
+- Laravel >= 9.0
 
 ## Instalation
 

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
     }
   ],
   "require": {
-    "php": "^7.4|^8.0",
-    "illuminate/console": "^6.0|^7.0|^8.0|^9.0",
-    "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
+    "php": "^8.1",
+    "illuminate/console": "^9.0|^10.0",
+    "illuminate/support": "^9.0|^10.0",
     "ext-json": "*",
     "aws/aws-sdk-php": "^3.134"
   },
   "require-dev": {
-    "phpunit/phpunit": "^9.5",
-    "orchestra/testbench": "^6.0",
-    "letsgoi/php-code-style": "^1.2"
+    "phpunit/phpunit": "^10.1",
+    "letsgoi/php-code-style": "^1.3",
+    "orchestra/testbench": "^7.2|^8.5"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
-    <testsuite name="Permissions Test Suite">
+    <testsuite name="Laravel Domain Event Messaging Test Suite">
       <directory>tests</directory>
     </testsuite>
   </testsuites>

--- a/src/Consumer/Drivers/ConsumerSqsDriver.php
+++ b/src/Consumer/Drivers/ConsumerSqsDriver.php
@@ -49,7 +49,7 @@ class ConsumerSqsDriver implements ConsumerContract
                     'timeout' => 60,
                     'connect_timeout' => 60,
                 ],
-            ]
+            ],
         );
 
         return (new Sdk($config))->createClient('sqs');


### PR DESCRIPTION
This PR adds compatibility to Laravel 10. Also remove support to PHP 7.4, 8.0, Laravel 6, Laravel 7 and Laravel 8.
Updates code style.
Updates PHPUnit to the last version.