### PR TITLE
Update support to PHP 8.3 and Laravel 11.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,10 +4,10 @@ on: [push]
 
 jobs:
   syntax:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist
@@ -16,10 +16,10 @@ jobs:
         run: composer syntax
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Install dependencies
         run: composer install -q --no-ansi --no-interaction --no-scripts --no-suggest --no-progress --prefer-dist

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ It's divided in two main elements:
 
 ## Requirements
 
-- PHP >= 8.1
-- Laravel >= 9.0
+- PHP >= 8.3
+- Laravel >= 10.0
 
 ## Instalation
 

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
     }
   ],
   "require": {
-    "php": "^8.1",
-    "illuminate/console": "^9.0|^10.0",
-    "illuminate/support": "^9.0|^10.0",
+    "php": "^8.3",
+    "illuminate/console": "^10.0|^11.0",
+    "illuminate/support": "^10.0|^11.0",
     "ext-json": "*",
     "aws/aws-sdk-php": "^3.134"
   },
   "require-dev": {
-    "phpunit/phpunit": "^10.1",
+    "phpunit/phpunit": "^11.2",
     "letsgoi/php-code-style": "^1.3",
-    "orchestra/testbench": "^7.2|^8.5"
+    "orchestra/testbench": "^9.1"
   },
   "autoload": {
     "psr-4": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   app:
     build: ./docker/php-cli

--- a/docker/php-cli/Dockerfile
+++ b/docker/php-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:8.1-cli-alpine
+FROM php:8.3-cli-alpine
 
 RUN apk add git
 

--- a/tests/Consumer/Console/ConsumeCommandTest.php
+++ b/tests/Consumer/Console/ConsumeCommandTest.php
@@ -5,48 +5,46 @@ namespace Letsgoi\DomainEventsMessaging\Tests\Consumer\Console;
 use Letsgoi\DomainEventsMessaging\Consumer\Consumer;
 use Letsgoi\DomainEventsMessaging\Tests\TestCase;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConsumeCommandTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_launch_consumer_as_a_daemon_on_consume_command()
     {
         $this->mock(Consumer::class, static function (MockInterface $mock) {
-            $mock->shouldReceive('daemon')
-                ->once();
+            $mock->expects('daemon');
         });
 
         $this->artisan('domain-events-messaging:consume');
     }
 
-    /** @test */
+    #[Test]
     public function it_should_launch_consumer_as_a_daemon_with_sleep_seconds_on_consume_command_with_sleep_parameter()
     {
         $this->mock(Consumer::class, static function (MockInterface $mock) {
-            $mock->shouldReceive('daemon')
-                ->with(5)
-                ->once();
+            $mock->expects('daemon')
+                ->with(5);
         });
 
         $this->artisan('domain-events-messaging:consume', ['--sleep' => 5]);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_launch_consumer_once_on_consume_command_with_once_parameter()
     {
         $this->mock(Consumer::class, static function (MockInterface $mock) {
-            $mock->shouldReceive('consume')
-                ->once();
+            $mock->expects('consume');
         });
 
         $this->artisan('domain-events-messaging:consume', ['--once' => true]);
     }
 
-    /** @test */
+    #[Test]
     public function it_should_not_launch_consumer_when_app_is_in_maintenance_on_consume_command()
     {
         $this->mock(Consumer::class, static function (MockInterface $mock) {
-            $mock->shouldReceive('daemon')
+            $mock->allows('daemon')
                 ->never();
         });
 
@@ -55,12 +53,11 @@ class ConsumeCommandTest extends TestCase
         $this->artisan('up');
     }
 
-    /** @test */
+    #[Test]
     public function it_should_launch_consumer_when_app_is_in_maintenance_on_consume_command_with_force_parameter()
     {
         $this->mock(Consumer::class, static function (MockInterface $mock) {
-            $mock->shouldReceive('daemon')
-                ->once();
+            $mock->expects('daemon');
         });
 
         $this->artisan('domain-events-messaging:consume', ['--force' => true]);

--- a/tests/Consumer/ConsumerTest.php
+++ b/tests/Consumer/ConsumerTest.php
@@ -13,10 +13,11 @@ use Letsgoi\DomainEventsMessaging\Tests\Stubs\FakeEvent;
 use Letsgoi\DomainEventsMessaging\Tests\Stubs\FakeJob;
 use Letsgoi\DomainEventsMessaging\Tests\Stubs\FakeNotDispatchableEvent;
 use Letsgoi\DomainEventsMessaging\Tests\TestCase;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConsumerTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_dispatch_event_on_consume_domain_event_message()
     {
         Event::fake();
@@ -38,7 +39,7 @@ class ConsumerTest extends TestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function it_should_dispatch_job_on_consume_domain_event_message()
     {
         Bus::fake();
@@ -60,7 +61,7 @@ class ConsumerTest extends TestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function it_should_throw_exception_on_consume_domain_event_message_with_not_dispatchable_event_associated()
     {
         $domainEventMessage = new DomainEventsMessage('message.subject', 'domain-message');

--- a/tests/Consumer/Drivers/ConsumerSqsDriverTest.php
+++ b/tests/Consumer/Drivers/ConsumerSqsDriverTest.php
@@ -7,22 +7,22 @@ use Illuminate\Support\Facades\Config;
 use Letsgoi\DomainEventsMessaging\Consumer\Drivers\ConsumerSqsDriver;
 use Letsgoi\DomainEventsMessaging\Tests\TestCase;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 class ConsumerSqsDriverTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_receive_message_and_delete_it_from_sqs_on_consume()
     {
         Config::set('domain_events_messaging.consumer.connections.sqs.queue_url', 'queue_url');
 
         $sqsClient = $this->mock(SqsClient::class, static function (MockInterface $mock) {
-            $mock->shouldReceive('receiveMessage')
+            $mock->expects('receiveMessage')
                 ->withArgs([[
                     'QueueUrl' => 'queue_url',
                     'MaxNumberOfMessages' => 1,
                 ]])
-                ->once()
-                ->andReturn([
+                ->andReturns([
                     'Messages' => [
                         [
                             'ReceiptHandle' => 'message-id',

--- a/tests/Publisher/Drivers/PublisherSnsDriverTest.php
+++ b/tests/Publisher/Drivers/PublisherSnsDriverTest.php
@@ -7,16 +7,17 @@ use Illuminate\Support\Facades\Config;
 use Letsgoi\DomainEventsMessaging\Publisher\Drivers\PublisherSnsDriver;
 use Letsgoi\DomainEventsMessaging\Tests\TestCase;
 use Mockery\MockInterface;
+use PHPUnit\Framework\Attributes\Test;
 
 class PublisherSnsDriverTest extends TestCase
 {
-    /** @test */
+    #[Test]
     public function it_should_send_message_on_sns_on_publish()
     {
         Config::set('domain_events_messaging.publisher.connections.sns.topic_arn', 'sns_topic_arn');
 
         $snsClient = $this->mock(SnsClient::class, static function (MockInterface $mock) {
-            $mock->shouldReceive('publish')
+            $mock->expects('publish')
                 ->withArgs([[
                     'TopicArn' => 'sns_topic_arn',
                     'Message' => 'message',
@@ -27,8 +28,7 @@ class PublisherSnsDriverTest extends TestCase
                             'StringValue' => 'event',
                         ],
                     ],
-                ]])
-                ->once();
+                ]]);
         });
 
         $publisherSnsDriver = new PublisherSnsDriver($snsClient);


### PR DESCRIPTION
This PR:

- Adds support to PHP 8.3.
- Updates Docker image to PHP 8.3.
- Adds support to Laravel 11.
- Removes support to Laravel 9.
- Updates to PHPUnit 11. Changes annotations to attributes, as annotations will be deleted in PHPUnit 12. https://docs.phpunit.de/en/11.2/attributes.html
- Updates GitHub workflow.

Private task: https://www.notion.so/00f5aede865e45e38dd39e5121b8ec73